### PR TITLE
Alternate NetSuite Base Directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Right-click the file/folder in the navigation panel to see the options:
 
 	// Temporary folder (e.g. C:\\temp) - used for storing compared file
 	"netSuiteUpload.tempFolder": "<TEMP FOLDER PATH>"
+
+	// Base NetSuite folder path to upload script to (e.g. )
+	"netSuiteUpload.rootDirectory": "<BASE FOLDER PATH>"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Right-click the file/folder in the navigation panel to see the options:
 	// Temporary folder (e.g. C:\\temp) - used for storing compared file
 	"netSuiteUpload.tempFolder": "<TEMP FOLDER PATH>"
 
-	// Base NetSuite folder path to upload script to (e.g. )
+	// Base NetSuite folder path to upload script to (e.g. "SuiteScripts/Developer")
 	"netSuiteUpload.rootDirectory": "<BASE FOLDER PATH>"
 }
 ```

--- a/helpers/netSuiteRestClient.js
+++ b/helpers/netSuiteRestClient.js
@@ -2,7 +2,12 @@ let vscode = require('vscode');
 let RestClient = require('node-rest-client').Client;
 
 function getRelativePath(absFilePath) {
-    return absFilePath.slice(vscode.workspace.rootPath.length);
+    var rootDirectory = vscode.workspace.getConfiguration('netSuiteUpload')['rootDirectory'];
+    if (rootDirectory) {
+        return rootDirectory + absFilePath.slice(vscode.workspace.rootPath.length);
+    } else {   
+        return 'SuiteScripts' + absFilePath.slice(vscode.workspace.rootPath.length);
+    }
 }
 
 function getFile(file, callback) {

--- a/netSuiteRestlet/vscodeExtensionRestlet.js
+++ b/netSuiteRestlet/vscodeExtensionRestlet.js
@@ -190,7 +190,7 @@ define(['N/file', 'N/search', 'N/record'], function (file, search, record) {
     }
 
     function postFile(relFilePath, content) {
-        var fullFilePath =  relFilePath;
+        var fullFilePath = relFilePath;
 
         try {
             var loadedFile = file.load({
@@ -207,7 +207,7 @@ define(['N/file', 'N/search', 'N/record'], function (file, search, record) {
     }
 
     function deleteFile(relFilePath) {
-        var fullFilePath =  relFilePath;
+        var fullFilePath = relFilePath;
 
         var fileObject = file.load({ id: fullFilePath });
         file.delete({ id: fileObject.id });

--- a/netSuiteRestlet/vscodeExtensionRestlet.js
+++ b/netSuiteRestlet/vscodeExtensionRestlet.js
@@ -130,7 +130,7 @@ define(['N/file', 'N/search', 'N/record'], function (file, search, record) {
     }
 
     function getFile(relFilePath) {
-        var fullFilePath = 'SuiteScripts' + relFilePath;
+        var fullFilePath = relFilePath;
         
         var fileToReturn = file.load({
             id: fullFilePath
@@ -144,7 +144,7 @@ define(['N/file', 'N/search', 'N/record'], function (file, search, record) {
     }
 
     function getDirectory(relDirectoryPath) {
-        var folderId = getFolderId('SuiteScripts' + relDirectoryPath);
+        var folderId = getFolderId(relDirectoryPath);
         var folders = getInnerFolders(relDirectoryPath, folderId)
         var allFiles = [];
         
@@ -190,7 +190,7 @@ define(['N/file', 'N/search', 'N/record'], function (file, search, record) {
     }
 
     function postFile(relFilePath, content) {
-        var fullFilePath = 'SuiteScripts' + relFilePath;
+        var fullFilePath =  relFilePath;
 
         try {
             var loadedFile = file.load({
@@ -207,7 +207,7 @@ define(['N/file', 'N/search', 'N/record'], function (file, search, record) {
     }
 
     function deleteFile(relFilePath) {
-        var fullFilePath = 'SuiteScripts' + relFilePath;
+        var fullFilePath =  relFilePath;
 
         var fileObject = file.load({ id: fullFilePath });
         file.delete({ id: fileObject.id });

--- a/package.json
+++ b/package.json
@@ -46,6 +46,10 @@
         "netSuiteUpload.tempFolder": {
           "type": "string",
           "description": "Temporary folder (e.g. C:\\temp)"
+        },
+        "netSuiteUpload.rootDirectory": {
+          "type": "string",
+          "description": "NetSuite root directory path to upload to, defaults to SuiteScript if blank"
         }
       }
     },


### PR DESCRIPTION
Here's another feature that might be useful for some users. That is, the ability to change the root directory in NetSuite from SuiteScripts to something else. For example, "SuiteScripts/Developer" would change the default directory to the Developer folder inside of the SuiteScripts folder. This will also be useful if you need to upload your files to a Bundle folder outside of the SuiteScripts folder. This might also help with this issue #2.